### PR TITLE
Added support for inline email attachments

### DIFF
--- a/src/main/java/net/sargue/mailgun/MultipartBuilder.java
+++ b/src/main/java/net/sargue/mailgun/MultipartBuilder.java
@@ -92,6 +92,21 @@ public class MultipartBuilder {
     }
 
     /**
+     * Adds a named inline attachment.
+     *
+     * @param is      an stream to read the attachment
+     * @param cidName the name to give to the attachment as referenced by the HTML email body
+     *                i.e. use cidName sample-image.png for the below example
+     *                <p>
+     *                    <img src="cid:sample-image.png"/>
+     *                </p>
+     * @return this builder
+     */
+    public MultipartBuilder inline(InputStream is, String cidName) {
+        return bodyPart(new StreamDataBodyPart("inline", is, cidName));
+    }
+
+    /**
      * Finishes the building phase and returns a {@link Mail}.
      * <p>
      * This builder should not be used after invoking this method.

--- a/src/test/java/net/sargue/mailgun/test/BasicTests.java
+++ b/src/test/java/net/sargue/mailgun/test/BasicTests.java
@@ -15,6 +15,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -192,6 +193,28 @@ public class BasicTests {
                         "readme.txt")
             .build()
             .send();
+        Assert.assertTrue(response.isOk());
+
+        //TODO proper content checking
+    }
+
+    @Test
+    public void sendWithInlineAttachment() {
+        stubFor(post(urlEqualTo("/api/" + DOMAIN + "/messages"))
+                .withHeader("Authorization",
+                        equalTo("Basic " + expectedAuthHeader))
+                .withHeader("Content-Type",
+                        containing("multipart/form-data"))
+                .willReturn(aResponse().withStatus(200)));
+
+        Response response = MailBuilder.using(configuration)
+                .to("doc@delorean.com")
+                .subject("This message has an text attachment")
+                .html("<html>Inline image here: <img src=\"cid:cartman.jpg\"></html>")
+                .multipart()
+                .inline(new ByteArrayInputStream("MockBytes".getBytes()), "cartman.jpg")
+                .build()
+                .send();
         Assert.assertTrue(response.isOk());
 
         //TODO proper content checking


### PR DESCRIPTION
Hi, I've decided to fork the project and add support for inline attachments as seen here: https://documentation.mailgun.com/user_manual.html#inline-image

and by this issue/feature request #4 